### PR TITLE
Xtrn improvements

### DIFF
--- a/bin/xtrn
+++ b/bin/xtrn
@@ -1,8 +1,21 @@
 #!/usr/bin/env ruby
 require 'xtrn'
 require 'yaml'
+require 'optparse'
 
-dir = Xtrn::Directory.new(YAML.load(File.open('Externals', 'rb', &:read)), Xtrn::Executor.new)
+options = {
+  file: 'Externals'
+}
+
+OptionParser.new do |opts|
+  opts.banner = 'Usage: xtrn [options]'
+  opts.on('-v', '--[no-]verbose', 'Run verbosely') { |v| options[:verbose] = v }
+  opts.on('-f', '--file FILE', 'File containing externals definition.') { |f| options[:file] = f }
+end.parse!
+
+raise OptionParser::InvalidArgument.new("File #{options[:file]} doesn't exist.") unless File.exists?(options[:file])
+
+dir = Xtrn::Directory.new(YAML::load_file(options[:file]), Xtrn::Executor.new(options), options)
 dir.update!
 
 GITIGNORE = '.gitignore'
@@ -10,4 +23,7 @@ GITIGNORE = '.gitignore'
 gitignore_contents = File.file?(GITIGNORE) ? File.open(GITIGNORE, 'rb', &:read) : ''
 updated_gitignore_contents = dir.updated_gitignore(gitignore_contents)
 
-File.open(GITIGNORE, 'wb') {|f|f.write(updated_gitignore_contents)} unless updated_gitignore_contents == gitignore_contents
+unless updated_gitignore_contents == gitignore_contents
+  puts 'Updating .gitignore contents.'
+  File.open(GITIGNORE, 'wb') {|f|f.write(updated_gitignore_contents)}
+end

--- a/bin/xtrn
+++ b/bin/xtrn
@@ -4,7 +4,8 @@ require 'yaml'
 require 'optparse'
 
 options = {
-  file: 'Externals'
+  file:    'Externals',
+  verbose: false
 }
 
 OptionParser.new do |opts|

--- a/bin/xtrn
+++ b/bin/xtrn
@@ -24,6 +24,6 @@ gitignore_contents = File.file?(GITIGNORE) ? File.open(GITIGNORE, 'rb', &:read) 
 updated_gitignore_contents = dir.updated_gitignore(gitignore_contents)
 
 unless updated_gitignore_contents == gitignore_contents
-  puts 'Updating .gitignore contents.'
+  puts 'Updating .gitignore contents.' if options[:verbose]
   File.open(GITIGNORE, 'wb') {|f|f.write(updated_gitignore_contents)}
 end

--- a/lib/xtrn/executor.rb
+++ b/lib/xtrn/executor.rb
@@ -1,8 +1,29 @@
+require 'open3'
+
 module Xtrn
   class Executor
-    def exec(cmd)
-      `#{cmd}`
+
+    DEFAULT_OPTS = {
+      verbose: false
+    }
+
+    def initialize(opts={})
+      opts      = DEFAULT_OPTS.merge(opts)
+      @verbose  = opts[:verbose]
     end
+
+    def exec(cmd)
+      puts "Exec: #{cmd}" if @verbose
+
+      stdout, stderr, status = Open3.capture3(cmd)
+
+      unless status.success?
+        puts "Aborting due to execution error:\n#{stderr}"
+        exit(1)
+      end
+
+      stdout
+    end
+
   end
 end
-

--- a/lib/xtrn/version.rb
+++ b/lib/xtrn/version.rb
@@ -1,3 +1,3 @@
 module Xtrn
-  VERSION = '0.1.6'
+  VERSION = '0.1.7'
 end


### PR DESCRIPTION
Improve robustness and add command line options:
- `-f`: Externals file name
- `-v`: Verbose output.

Tested by modifying the Gemfile:

```
gem 'xtrn', '>= 0.1.7', :git => 'https://github.com/viktorium/xtrn.git', :branch => 'new-svn-versions-fix'
```

Or directly from a repo clone:

```
env RUBYLIB=/home/user/work/ruby/xtrn/lib /home/user/work/ruby/xtrn/bin/xtrn -v
```
